### PR TITLE
Improve fingerprint uniqueness with SHA-256 hash

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -53,7 +53,7 @@ const App: React.FC = () => {
           {fingerprint && (
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
               <div className="lg:col-span-1 flex justify-center items-center">
-                <EntropyVisualizer entropy={fingerprint.entropy} maxEntropy={40} />
+                <EntropyVisualizer entropy={fingerprint.entropy} maxEntropy={fingerprint.maxEntropy} />
               </div>
               <div className="lg:col-span-2">
                 <FingerprintDisplay data={fingerprint} />

--- a/types.ts
+++ b/types.ts
@@ -8,4 +8,5 @@ export interface FingerprintData {
   visitorId: string;
   details: FingerprintDetails;
   entropy: number;
+  maxEntropy: number;
 }


### PR DESCRIPTION
## Summary
- use crypto.subtle SHA-256 for fingerprint hashing
- expose `maxEntropy` from fingerprint service
- display entropy visualization using the dynamic max

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f57ac858c832fada39ada7e592c09